### PR TITLE
Add rspec definitions for riscv payloads

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1996,6 +1996,26 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/riscv32le/reboot'
   end
 
+  context 'linux/riscv32le/shell/bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/linux/riscv32le/bind_tcp',
+                              'stages/linux/riscv32le/shell'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/riscv32le/shell/bind_tcp'
+  end
+
+  context 'linux/riscv32le/shell/reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/linux/riscv32le/reverse_tcp',
+                              'stages/linux/riscv32le/shell'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/riscv32le/shell/reverse_tcp'
+  end
+
   context 'linux/riscv32le/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -2039,6 +2059,26 @@ RSpec.describe 'modules/payloads', :content do
                           ],
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/riscv64le/reboot'
+  end
+
+  context 'linux/riscv64le/shell/bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/linux/riscv64le/bind_tcp',
+                              'stages/linux/riscv64le/shell'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/riscv64le/shell/bind_tcp'
+  end
+
+  context 'linux/riscv64le/shell/reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/linux/riscv64le/reverse_tcp',
+                              'stages/linux/riscv64le/shell'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/riscv64le/shell/reverse_tcp'
   end
 
   context 'linux/riscv64le/shell_bind_tcp' do


### PR DESCRIPTION
I'm getting a little crazy with the rspec inconsistencies.  I'm seeing different results running things on Github and locally, and non-deterministic behavior all-around.
It does not help that the fix here is not considered a test failure (and is not listed as a failure), but is an `error` that will cause the tests to fail 😞 
Locally, this change makes the branch pass (and also not error).  I simply fail to understand why Github testing is complaining about payload cache size for _windows_ payloads:
```
    0.83565 seconds ./spec/support/shared/examples/payload_cached_size_is_consistent.rb:113
  modules/payloads windows/shell/reverse_tcp_rc4 it should behave like payload cached size is consistent windows/shell/reverse_tcp_rc4 has a valid cached_size
```

Anyway, this PR fixes the `error` in rspec so even though everything passes, the tests will pass:
```
An error occurred in an `after(:context)` hook.
Failure/Error: expect(missing_ancestor_reference_name_set).to be_empty, "Some payloads are untested: #{missing_ancestor_reference_name_set.join(', ')}. Please update `modules/payloads_spec.rb` with the payload definitions"
  Some payloads are untested: stagers/linux/riscv32le/bind_tcp, stagers/linux/riscv32le/reverse_tcp, stagers/linux/riscv64le/bind_tcp, stagers/linux/riscv64le/reverse_tcp, stages/linux/riscv32le/shell, stages/linux/riscv64le/shell. Please update `modules/payloads_spec.rb` with the payload definitions
# ./spec/support/shared/contexts/untested_payloads.rb:62:in `block (2 levels) in <top (required)>'
...
Finished in 8 minutes 36 seconds (files took 9.15 seconds to load)
18794 examples, 0 failures, 33 pending, 1 error occurred outside of examples

```

Thanks for listening to me rant, and thank you for being patient. </rant>